### PR TITLE
Fix crashing statsderl application on udp errors

### DIFF
--- a/src/statsderl_server.erl
+++ b/src/statsderl_server.erl
@@ -56,6 +56,9 @@ handle_msg({cast, Packet}, #state {
     end,
     {ok, State};
 handle_msg({inet_reply, _Socket, ok}, State) ->
+    {ok, State};
+handle_msg({inet_reply, _Socket, {error, Reason}}, State) ->
+    statsderl_utils:error_msg("inet_reply ~p: ~p~n", [error, Reason]),
     {ok, State}.
 
 loop(State) ->


### PR DESCRIPTION
I have made this change as a workaround for issue #20. I still don't understand fully why erlang is reporting udp errors on my environment, but this fix makes it not crash at least.

I think it will be beneficial for everybody, just catching all posix errors coming from socket and logging them, rather than crashing whole application, don't you think? 

If you think it would be better to crash server only and have it restarted by master supervisor with some protection for it crashing to often, then I can work on this patch to meet your requirements for error handling.