### PR TITLE
Performance optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,6 @@ make test
 
 ### TODOs
 
-* NIF for faster random
-* parse transform for severity levels (debug, development, production)
 * parse transform for type conversion
 
 ## License

--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,7 @@
 
 {deps, [
   {granderl, ".*",
-    {git, "https://github.com/tokenrove/granderl.git", {tag, "v0.1.1"}}}
+    {git, "https://github.com/tokenrove/granderl.git", {tag, "v0.1.4"}}}
 ]}.
 
 {edoc_opts, [

--- a/src/statsderl.erl
+++ b/src/statsderl.erl
@@ -14,7 +14,8 @@
     increment/3,
     timing/3,
     timing_fun/3,
-    timing_now/3
+    timing_now/3,
+    timing_now_us/3
 ]).
 
 %% public
@@ -66,6 +67,11 @@ timing_fun(Key, Fun, SampleRate) ->
 timing_now(Key, Timestamp, SampleRate) ->
     maybe_cast(timing_now, Key, Timestamp, SampleRate).
 
+-spec timing_now_us(key(), erlang:timestamp(), sample_rate()) -> ok.
+
+timing_now_us(Key, Timestamp, SampleRate) ->
+    maybe_cast(timing_now_us, Key, Timestamp, SampleRate).
+
 %% private
 cast(OpCode, Key, Value, SampleRate) ->
     ServerName = statsderl_utils:random_server(),
@@ -77,10 +83,14 @@ cast(OpCode, Key, Value, SampleRate, ServerName) ->
 
 maybe_cast(timing_now, Key, Value, 1) ->
     cast(timing, Key, timing_now(Value), 1);
+maybe_cast(timing_now_us, Key, Value, 1) ->
+    cast(timing, Key, timing_now_us(Value), 1);
 maybe_cast(OpCode, Key, Value, 1) ->
     cast(OpCode, Key, Value, 1);
 maybe_cast(timing_now, Key, Value, 1.0) ->
     cast(timing, Key, timing_now(Value), 1.0);
+maybe_cast(timing_now_us, Key, Value, 1.0) ->
+    cast(timing, Key, timing_now_us(Value), 1.0);
 maybe_cast(OpCode, Key, Value, 1.0) ->
     cast(OpCode, Key, Value, 1);
 maybe_cast(OpCode, Key, Value, SampleRate) ->
@@ -92,6 +102,9 @@ maybe_cast(OpCode, Key, Value, SampleRate) ->
             case OpCode of
                 timing_now ->
                     cast(timing, Key, timing_now(Value), SampleRate,
+                        ServerName);
+                timing_now_us ->
+                    cast(timing, Key, timing_now_us(Value), SampleRate,
                         ServerName);
                 _ ->
                     cast(OpCode, Key, Value, SampleRate, ServerName)
@@ -110,5 +123,8 @@ send(ServerName, Msg) ->
     end.
 
 timing_now(Timestamp) ->
+    timing_now_us(Timestamp) div 1000.
+
+timing_now_us(Timestamp) ->
     Timestamp2 = statsderl_utils:timestamp(),
-    timer:now_diff(Timestamp2, Timestamp) div 1000.
+    timer:now_diff(Timestamp2, Timestamp).

--- a/src/statsderl.erl
+++ b/src/statsderl.erl
@@ -99,7 +99,7 @@ maybe_cast(OpCode, Key, Value, SampleRate) ->
 
 send(ServerName, Msg) ->
     try
-        whereis(ServerName) ! Msg,
+        ServerName ! Msg,
         ok
     catch
         error:badarg ->

--- a/src/statsderl.erl
+++ b/src/statsderl.erl
@@ -1,6 +1,9 @@
 -module(statsderl).
 -include("statsderl.hrl").
 
+-compile(inline).
+-compile({inline_size, 512}).
+
 %% public
 -export([
     counter/3,

--- a/src/statsderl_protocol.erl
+++ b/src/statsderl_protocol.erl
@@ -1,6 +1,9 @@
 -module(statsderl_protocol).
 -include("statsderl.hrl").
 
+-compile(inline).
+-compile({inline_size, 512}).
+
 -export([
     encode/4
 ]).

--- a/src/statsderl_protocol.erl
+++ b/src/statsderl_protocol.erl
@@ -12,21 +12,22 @@
 -spec encode(op_code(), key(), value(), sample_rate()) -> iodata().
 
 encode(counter, Key, Value, SampleRate) ->
-    [Key, ":", format_value(Value), "|c", format_sample_rate(SampleRate)];
+    [Key, <<":">>, format_value(Value), <<"|c">>,
+        format_sample_rate(SampleRate)];
 encode(gauge, Key, Value, _SampleRate) ->
-    [Key, ":", format_value(Value), "|g"];
+    [Key, <<":">>, format_value(Value), <<"|g">>];
 encode(gauge_decrement, Key, Value, _SampleRate) ->
-    [Key, ":-", format_value(Value), "|g"];
+    [Key, <<":-">>, format_value(Value), <<"|g">>];
 encode(gauge_increment, Key, Value, _SampleRate) ->
-    [Key, ":+", format_value(Value), "|g"];
+    [Key, <<":+">>, format_value(Value), <<"|g">>];
 encode(timing, Key, Value, _SampleRate) ->
-    [Key, ":", format_value(Value), "|ms"].
+    [Key, <<":">>, format_value(Value), <<"|ms">>].
 
 %% private
 format_sample_rate(SampleRate) when SampleRate >= 1 ->
-    "";
+    <<>>;
 format_sample_rate(SampleRate) ->
-    ["|@", float_to_list(SampleRate, [{decimals, 3}])].
+    [<<"|@">>, float_to_list(SampleRate, [{decimals, 3}])].
 
 format_value(Value) when is_integer(Value) ->
     integer_to_list(Value);

--- a/src/statsderl_server.erl
+++ b/src/statsderl_server.erl
@@ -1,6 +1,9 @@
 -module(statsderl_server).
 -include("statsderl.hrl").
 
+-compile(inline).
+-compile({inline_size, 512}).
+
 -export([
     init/2,
     start_link/1

--- a/test/statsderl_profile.erl
+++ b/test/statsderl_profile.erl
@@ -19,7 +19,7 @@ fprofx() ->
 
     Self = self(),
     [spawn(fun () ->
-        increment(),
+        timing_now(),
         Self ! exit
     end) || _ <- lists:seq(1, ?P)],
     wait(),
@@ -32,8 +32,9 @@ fprofx() ->
     ok.
 
 %% private
-increment() ->
-    [statsderl:increment(["test", <<".test">>], 1, 0.25) ||
+timing_now() ->
+    Timestamp = os:timestamp(),
+    [statsderl:timing_now(["test", <<".test">>], Timestamp, 0.25) ||
         _ <- lists:seq(1, ?N)].
 
 preload_modules() ->


### PR DESCRIPTION
- Optimize timing_now call
- Remove useless whereis call
- Force inlining
- Update `granderl`
- Use binaries instead of lists for protocol encoding