### PR TITLE
Fix sampling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,10 @@ cache:
   directories:
     - $HOME/.cache/rebar3
     - $TRAVIS_BUILD_DIR/_build
+dist: trusty
 env:
   - CC=gcc-5
+group: edge
 install: true
 language: erlang
 notifications:
@@ -18,4 +20,3 @@ otp_release:
   - 19.1
   - 18.3
 script: "make travis"
-sudo: false

--- a/src/statsderl_protocol.erl
+++ b/src/statsderl_protocol.erl
@@ -27,7 +27,7 @@ encode({timing, Key, Value}) ->
 format_sample_rate(SampleRate) when SampleRate >= 1 ->
     <<>>;
 format_sample_rate(SampleRate) ->
-    [<<"|@">>, float_to_list(SampleRate, [{decimals, 3}])].
+    [<<"|@">>, float_to_list(SampleRate, [compact, {decimals, 6}])].
 
 format_value(Value) when is_integer(Value) ->
     integer_to_list(Value);

--- a/test/statsderl_tests.erl
+++ b/test/statsderl_tests.erl
@@ -67,7 +67,7 @@ sampling_rate_subtest(Socket) ->
     meck:new(granderl, [passthrough, no_history]),
     meck:expect(granderl, uniform, fun (?MAX_UNSIGNED_INT_32) -> 1 end),
     statsderl:counter("test", 1, 0.1234),
-    assert_packet(Socket, <<"test:1|c|@0.123">>),
+    assert_packet(Socket, <<"test:1|c|@0.1234">>),
     meck:expect(granderl, uniform, fun (?MAX_UNSIGNED_INT_32) ->
         ?MAX_UNSIGNED_INT_32
     end),


### PR DESCRIPTION
Fix `sample_rate` truncation if sample is < 0.001.

```erlang
1> float_to_list(0.0005, [{decimals, 3}]).
"0.001"
```