### PR TITLE
Update spec for timing_fun, tests to match new behavior

### DIFF
--- a/src/statsderl.erl
+++ b/src/statsderl.erl
@@ -62,7 +62,7 @@ timing(Key, Value, Rate) ->
     statsderl_pool:sample(Rate, {timing, Key, Value}).
 
 -spec timing_fun(key(), fun(), sample_rate()) ->
-    ok.
+    any().
 
 timing_fun(Key, Fun, Rate) ->
     Timestamp = statsderl_utils:timestamp(),

--- a/test/statsderl_tests.erl
+++ b/test/statsderl_tests.erl
@@ -78,8 +78,10 @@ timing_fun_subtest(Socket) ->
     meck:new(statsderl_utils, [passthrough, no_history]),
     Seq = meck:loop([{1448, 573975, 400000}, {1448, 573975, 500000}]),
     meck:expect(statsderl_utils, timestamp, [], Seq),
-    statsderl:timing_fun("test", fun () -> ok end, 1),
+    TestResult = "testresult",
+    Result = statsderl:timing_fun("test", fun () -> TestResult end, 1),
     assert_packet(Socket, <<"test:100|ms">>),
+    ?assertEqual(Result, TestResult),
     meck:unload(statsderl_utils).
 
 timing_subtest(Socket) ->


### PR DESCRIPTION
`timing_fun`'s spec only matches functions that return `ok`. Updated this to return anything from a function as well as tests to match changes.

Fixes #53 